### PR TITLE
60 make better response on transcription

### DIFF
--- a/modules/backend/Directory.Packages.props
+++ b/modules/backend/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/modules/backend/src/Au5.Application/ConfigServices.cs
+++ b/modules/backend/src/Au5.Application/ConfigServices.cs
@@ -7,7 +7,7 @@ public static class ConfigureServices
 {
 	public static IServiceCollection RegisterApplicationServices(this IServiceCollection services)
 	{
-		services.AddSingleton<IMeetingService, MeetingService>();
+		services.AddScoped<IMeetingService, MeetingService>();
 		services.AddScoped<IReactionService, ReactionService>();
 		services.AddScoped<IAuthenticationService, AuthenticationService>();
 

--- a/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
+++ b/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
@@ -16,7 +16,7 @@ public interface IMeetingService
 
 	void InsertBlock(EntryMessage entry);
 
-	Task<Result<object>> GetFullTranscriptionAsJson(string meetId);
+	Task<Result<object>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default);
 
 	void AppliedReaction(ReactionAppliedMessage reaction);
 

--- a/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
+++ b/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
@@ -16,7 +16,7 @@ public interface IMeetingService
 
 	void InsertBlock(EntryMessage entry);
 
-	Meeting GetFullTranscriptionAsJson(string meetId);
+	Task<Result<object>> GetFullTranscriptionAsJson(string meetId);
 
 	void AppliedReaction(ReactionAppliedMessage reaction);
 

--- a/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
+++ b/modules/backend/src/Au5.Application/Interfaces/IMeetingService.cs
@@ -1,3 +1,5 @@
+using Au5.Application.Models.Dtos.MeetingDtos;
+
 namespace Au5.Application.Interfaces;
 
 public interface IMeetingService
@@ -16,7 +18,7 @@ public interface IMeetingService
 
 	void InsertBlock(EntryMessage entry);
 
-	Task<Result<object>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default);
+	Task<Result<FullMeetingTranscriptionDto>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default);
 
 	void AppliedReaction(ReactionAppliedMessage reaction);
 

--- a/modules/backend/src/Au5.Application/MeetingService.cs
+++ b/modules/backend/src/Au5.Application/MeetingService.cs
@@ -182,7 +182,7 @@ public class MeetingService(IReactionService reactionService) : IMeetingService
 		}
 	}
 
-	public async Task<Result<object>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default)
+	public async Task<Result<FullMeetingTranscriptionDto>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default)
     {
         var meeting = Meetings.FirstOrDefault(m => m.MeetId == meetId);
         if (meeting is null || meeting.Entries == null || meeting.Entries.Count == 0)

--- a/modules/backend/src/Au5.Application/MeetingService.cs
+++ b/modules/backend/src/Au5.Application/MeetingService.cs
@@ -185,7 +185,7 @@ public class MeetingService(IReactionService reactionService) : IMeetingService
 	public async Task<Result<FullMeetingTranscriptionDto>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default)
     {
         var meeting = Meetings.FirstOrDefault(m => m.MeetId == meetId);
-        if (meeting is null || meeting.Entries == null || meeting.Entries.Count == 0)
+        if (meeting is null)
         {
             return Error.NotFound(description: "No meeting with this ID was found.");
         }
@@ -194,7 +194,7 @@ public class MeetingService(IReactionService reactionService) : IMeetingService
             .OrderBy(e => e.Timestamp)
             .ToList();
 
-        var baseTime = orderedEntries.First().Timestamp;
+        var baseTime = meeting.CreatedAt;
         var reactionsList = await _reationService.GetAllAsync(ct);
 
         var result = new FullMeetingTranscriptionDto(

--- a/modules/backend/src/Au5.Application/MeetingService.cs
+++ b/modules/backend/src/Au5.Application/MeetingService.cs
@@ -181,7 +181,7 @@ public class MeetingService(IReactionService reactionService) : IMeetingService
 		}
 	}
 
-	public async Task<Result<object>> GetFullTranscriptionAsJson(string meetId)
+	public async Task<Result<object>> GetFullTranscriptionAsJson(string meetId, CancellationToken ct = default)
 	{
 		var meeting = Meetings.FirstOrDefault(m => m.MeetId == meetId);
 		if (meeting is null || meeting.Entries == null || meeting.Entries.Count == 0)
@@ -194,7 +194,7 @@ public class MeetingService(IReactionService reactionService) : IMeetingService
 			.ToList();
 
 		var baseTime = orderedEntries.First().Timestamp;
-		var reactionsList = await _reationService.GetAllAsync();
+		var reactionsList = await _reationService.GetAllAsync(ct);
 
 		var result = new
 		{

--- a/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/EntryDto.cs
+++ b/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/EntryDto.cs
@@ -1,0 +1,11 @@
+namespace Au5.Application.Models.Dtos.MeetingDtos;
+
+public record EntryDto(
+	Guid blockId,
+	Guid participantId,
+	string content,
+	string timestamp,
+	string timeline,
+	string entryType,
+	IReadOnlyList<ReactionDto> reactions
+);

--- a/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/FullMeetingTranscriptionsDto.cs
+++ b/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/FullMeetingTranscriptionsDto.cs
@@ -1,0 +1,16 @@
+namespace Au5.Application.Models.Dtos.MeetingDtos;
+
+public record FullMeetingTranscriptionDto(
+	Guid id,
+	string meetingId,
+	Guid creatorUserId,
+	Guid botInviterUserId,
+	string hashToken,
+	string platform,
+	string botName,
+	bool isBotAdded,
+	string createdAt,
+	string status,
+	IReadOnlyList<ParticipantDto> participants,
+	IReadOnlyList<EntryDto> entries
+);

--- a/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/ParticipantDto.cs
+++ b/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/ParticipantDto.cs
@@ -1,0 +1,7 @@
+namespace Au5.Application.Models.Dtos.MeetingDtos;
+
+public record ParticipantDto(
+	Guid userId,
+	string fullName,
+	string pictureUrl
+);

--- a/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/ReactionDto.cs
+++ b/modules/backend/src/Au5.Application/Models/Dtos/MeetingDtos/ReactionDto.cs
@@ -1,0 +1,9 @@
+namespace Au5.Application.Models.Dtos.MeetingDtos;
+
+public record ReactionDto(
+	int id,
+	string type,
+	string emoji,
+	string className,
+	IReadOnlyList<Guid> users
+);

--- a/modules/backend/src/Au5.BackEnd/Controllers/AuthenticationController.cs
+++ b/modules/backend/src/Au5.BackEnd/Controllers/AuthenticationController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace Au5.BackEnd.Controllers;
 
-[Route("authentication")]
 public class AuthenticationController(IAuthenticationService authenticationService) : BaseController
 {
 	private readonly IAuthenticationService _authenticationService = authenticationService;

--- a/modules/backend/src/Au5.BackEnd/Controllers/BaseController.cs
+++ b/modules/backend/src/Au5.BackEnd/Controllers/BaseController.cs
@@ -1,10 +1,10 @@
-﻿using Au5.BackEnd.Filters;
+using Au5.BackEnd.Filters;
 
 namespace Au5.BackEnd.Controllers;
 
 [ApiController]
 [ResultHandlingActionFilter]
-[Route("/[controller]")]
+[Route("[controller]")]
 public class BaseController : ControllerBase
 {
 	public int CurrentUserId => throw new NotImplementedException();

--- a/modules/backend/src/Au5.BackEnd/Controllers/MeetingController.cs
+++ b/modules/backend/src/Au5.BackEnd/Controllers/MeetingController.cs
@@ -4,7 +4,7 @@ public class MeetingController(IMeetingService meetingService) : BaseController
 {
 	private readonly IMeetingService _meetingService = meetingService;
 
-	[HttpGet("/{meetingId}/transcription")]
+	[HttpGet("{meetingId}/transcription")]
 	public async Task<IActionResult> Transcripitons([FromRoute] string meetingId, CancellationToken ct)
 	{
 		return Ok(await _meetingService.GetFullTranscriptionAsJson(meetingId, ct));

--- a/modules/backend/src/Au5.BackEnd/Controllers/MeetingController.cs
+++ b/modules/backend/src/Au5.BackEnd/Controllers/MeetingController.cs
@@ -1,0 +1,12 @@
+namespace Au5.BackEnd.Controllers;
+
+public class MeetingController(IMeetingService meetingService) : BaseController
+{
+	private readonly IMeetingService _meetingService = meetingService;
+
+	[HttpGet("/{meetingId}/transcription")]
+	public async Task<IActionResult> Transcripitons([FromRoute] string meetingId, CancellationToken ct)
+	{
+		return Ok(await _meetingService.GetFullTranscriptionAsJson(meetingId, ct));
+	}
+}

--- a/modules/backend/src/Au5.BackEnd/Program.cs
+++ b/modules/backend/src/Au5.BackEnd/Program.cs
@@ -64,14 +64,6 @@ var app = builder.Build();
 		return Results.Ok(new { Success = true, Message = $"Bot added to meeting {request.MeetId}", Data = result });
 	});
 
-	app.MapGet("/meeting/{meetingId}/transcription", (
-		[FromRoute] string meetingId,
-		[FromServices] IMeetingService meetingService) =>
-	{
-		var transcription = meetingService.GetFullTranscriptionAsJson(meetingId);
-		return Results.Json(transcription);
-	});
-
 	app.MapGet("/reactions", async (IReactionService reactionService, CancellationToken ct) =>
 	{
 		return Results.Ok(await reactionService.GetAllAsync(ct).ConfigureAwait(false));

--- a/modules/backend/tests/Au5.UnitTests/Au5.UnitTests.csproj
+++ b/modules/backend/tests/Au5.UnitTests/Au5.UnitTests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
#### PR Classification
This pull request refactors GetFullTranscriptionAsJson method to support asynchronous operations in the meeting service and having cleaner result.

#### PR Summary
The changes enhance the meeting service by implementing asynchronous methods for fetching meeting transcriptions and introducing new data transfer objects (DTOs) for better data structure. 

Using `meeting.CreatedAt` instead of `parsedEntries.First().ParsedTimestamp` As the BASELINE  to ensure that an error does not raise when the entries list is empty.

- `IMeetingService.cs`: Updated `GetFullTranscriptionAsJson` to return `Task<Result<FullMeetingTranscriptionDto>>`.
- `MeetingService.cs`: Implemented the new asynchronous method for fetching full meeting transcriptions with detailed handling of entries and reactions.
- `MeetingController.cs`: Updated to utilize the new asynchronous transcription fetching method.
- `MeetingServiceTests.cs`: Refactored tests to accommodate asynchronous methods and new DTO structures, ensuring proper validation.
- `Directory.Packages.props`: Added a new package reference for Moq version 4.20.72.
