### PR TITLE
Potential fix for code scanning alert no. 4: Client-side cross-site scripting

### DIFF
--- a/modules/extension/src/ui/chatPanel.ts
+++ b/modules/extension/src/ui/chatPanel.ts
@@ -286,7 +286,7 @@ export class ChatPanel {
         if (url.length > 36) {
           displayUrl = url.slice(0, 36) + "(*)";
         }
-        el.innerHTML = displayUrl;
+        el.textContent = displayUrl;
       }
     });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Au5-ai/Au5/security/code-scanning/4](https://github.com/Au5-ai/Au5/security/code-scanning/4)

To fix the issue, the `url` parameter should be sanitized or encoded before being assigned to the `innerHTML` property. The best approach is to use contextual output encoding to ensure that any special characters in the `url` are properly escaped, preventing the execution of malicious scripts. Specifically:
1. Replace the use of `innerHTML` with `textContent` to avoid interpreting the input as HTML.
2. Update the `setUrl` method in `modules/extension/src/ui/chatPanel.ts` to use `textContent` instead of `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
