### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/modules/extension/src/ui/chatPanel.ts
+++ b/modules/extension/src/ui/chatPanel.ts
@@ -10,6 +10,14 @@ import {
 import {DateTime} from "../core/utils/datetime";
 const DEFAULT_AVATAR_URL = "assets/icons/default-avatar.jpg";
 export class ChatPanel {
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
   private unauthorizedContainerEl: HTMLElement | null;
   private noActiveMeetingEl: HTMLElement | null;
   private activeMeetingButNotStartedEl: HTMLElement | null;
@@ -106,12 +114,12 @@ export class ChatPanel {
 
     <div class="au5-message-bubble">
       <div class="au5-message-header">
-        <span class="au5-message-sender">${entry.participant.fullName}</span>
+        <span class="au5-message-sender">${this.escapeHtml(entry.participant.fullName)}</span>
         <span class="au5-message-time">${DateTime.toHoursAndMinutes(entry.timestamp)}</span>
       </div>
 
       <div class="au5-message-text" style="direction: ${this.direction};">
-        ${entry.content}
+        ${this.escapeHtml(entry.content)}
       </div>
 
       ${this.getReactionsHtml(entry.blockId)} 


### PR DESCRIPTION
Potential fix for [https://github.com/Au5-ai/Au5/security/code-scanning/2](https://github.com/Au5-ai/Au5/security/code-scanning/2)

To fix the issue, the untrusted `entry.content` should be properly escaped before being interpolated into the HTML string. Escaping ensures that any special characters in the user input are treated as plain text rather than HTML or JavaScript. 

The best way to fix this is to use a utility function to escape the content before interpolation. This function can replace special characters like `<`, `>`, `&`, and `"` with their corresponding HTML entities (`&lt;`, `&gt;`, `&amp;`, `&quot;`).

#### Steps to implement the fix:
1. Add an HTML escaping utility function to safely encode user input.
2. Use this utility function to escape `entry.content` before interpolating it into the HTML string in `chatPanel.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
